### PR TITLE
Added slash if necessary (windows support)

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -31,7 +31,11 @@ const getActiveFilePath = () => {
 const getActiveLineNumber = () => get(vscode,'window.activeTextEditor.selection.active.line')
 
 const makeAppLink = (path, lineNumber) => {
-	const appLinkPrefix = 'vscode://file'
+	let appLinkPrefix = 'vscode://file'
+	if (path[0] != "/" && path[0] != "\\") {
+		appLinkPrefix += "/";
+	}
+	
 	const fileLink = `${appLinkPrefix}${path}`
 	return lineNumber
 		? `${fileLink}:${lineNumber}`


### PR DESCRIPTION
Adding the slash makes the link formatted correctly on windows. I have not tested on Mac, so there is a crappy conditional that hopefully makes it work for both.